### PR TITLE
fixing () => in message back

### DIFF
--- a/languages/en_US.js
+++ b/languages/en_US.js
@@ -207,8 +207,8 @@ module.exports = class extends Language {
             },
 
             //Acronym Command
-            COMMAND_ACRONYMS_INVALID: () => `Acronym lookup provided not available for blank`,
-            COMMAND_ACRONYMS_NOT_FOUND: () => `Acronym could not be found`,
+            COMMAND_ACRONYMS_INVALID: `Acronym lookup provided not available for blank`,
+            COMMAND_ACRONYMS_NOT_FOUND: `Acronym could not be found`,
             COMMAND_ACRONYMS_HELP: {
                 description: "Helps to provide a lookup for the acronyms commonly used in Star Wars: Galaxy of Heros.",
                 actions: [


### PR DESCRIPTION
The () => in the message is showing up directly in the message :/


![screen shot 2018-11-14 at 11 40 08 am](https://user-images.githubusercontent.com/872224/48501132-14b84780-e802-11e8-912e-879c36668f27.png)
